### PR TITLE
Fix bug and pin magicgui (0.1.6)

### DIFF
--- a/paintedlife/game_of_life.py
+++ b/paintedlife/game_of_life.py
@@ -126,7 +126,7 @@ class GameOfLife(PatternGenerator):
         e = partial(evolve, self)
         e = partial(e, self.viewer)
         e = partial(e, self.timeit)
-        e = magicgui(e, call_button='Evolve', layout='form')
+        e = magicgui(e, call_button='Evolve')
         evolve_gui = e.Gui()
         self.viewer.window.add_dock_widget(evolve_gui)
         self.viewer.layers.events.changed.connect(lambda x: evolve_gui.refresh_choices())

--- a/paintedlife/game_of_life.py
+++ b/paintedlife/game_of_life.py
@@ -243,7 +243,7 @@ class GameOfLife(PatternGenerator):
     def _add_GOL_to_viewer(self):
         try:
             del self.viewer.layers['Game of Life']
-        except ValueError:
+        except:
             pass
         self.viewer.add_labels(self.history, name='Game of Life', opacity=1.0)
         self.viewer.layers["Game of Life"].seed = self.seed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scipy
 numpy
 napari[all]
-magicgui
+magicgui==0.1.6

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ DESCRIPTION = "Conway's Game of Life, napari style (paintbrush inc.)"
 
 setup(
       name='paintedlife', 
-      version='0.0.1', 
+      version='0.0.3', 
       description=DESCRIPTION, 
       long_description_content_type='text/markdown',
       author='Abigail S. McGovern',
@@ -23,7 +23,5 @@ setup(
       classifiers=[
                    'Programming Language :: Python',
                    'Programming Language :: Python :: 3 :: Only',
-                   'Topic :: Mathematics',
-                   'Topic :: Mathematics :: Cellular Automata :: B3/S23'
                    ]
       )


### PR DESCRIPTION
## Changes
- Fix bug – incorrect exception was used in a try except block
- Pin `magicgui==0.1.6` – the evolve widget no longer works with 0.2.0 

## For later PR
- adapt for `magicgui>=0.2.0` or use `qt` widgets directly

